### PR TITLE
Add AI Virtual Try-On Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Try-It-Out
+# AI Virtual Try-On Chrome Extension
+
+This repository contains a sample Chrome extension that lets users try on clothing products virtually using an external AI service. The extension detects product images on supported e-commerce sites and sends them along with a user photo to a backend for processing.
+
+## Supported Sites
+- amazon.com
+- myntra.com
+- flipkart.com
+- zara.com
+
+## Development
+1. Open `chrome://extensions` in Chrome.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this folder.
+4. Visit a supported product page and open the extension popup.
+
+The popup allows uploading a user photo and sends it together with the detected product image to a backend endpoint (currently set to `https://httpbin.org/post`). Replace the `API_ENDPOINT` value in `popup.js` with your actual backend URL.
+
+## Notes
+This is a proof-of-concept and uses simple selectors for each site. Real-world usage may require more robust DOM parsing and error handling.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,19 @@
+// Background service worker for AI Virtual Try-On extension
+// Stores product image URLs and relays data between content scripts and popup.
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'SET_PRODUCT_IMAGE') {
+    chrome.storage.local.set({ productImageUrl: message.url }, () => {
+      sendResponse({ status: 'ok' });
+    });
+    // indicate asynchronous response
+    return true;
+  }
+
+  if (message.type === 'GET_PRODUCT_IMAGE') {
+    chrome.storage.local.get('productImageUrl', (data) => {
+      sendResponse({ url: data.productImageUrl });
+    });
+    return true;
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,29 @@
+// Content script to detect product images on supported e-commerce sites
+// Sends the main product image URL to the background service worker.
+
+(function() {
+  function detectImage() {
+    const host = location.hostname;
+    let imgUrl = null;
+
+    if (host.includes('amazon.')) {
+      imgUrl = document.querySelector('#landingImage')?.src;
+    } else if (host.includes('myntra.')) {
+      imgUrl = document.querySelector('img[itemprop="image"]')?.src;
+    } else if (host.includes('flipkart.')) {
+      imgUrl = document.querySelector('img._2r_T1I')?.src;
+    } else if (host.includes('zara.')) {
+      imgUrl = document.querySelector('img[data-qa-model="image"]')?.src;
+    }
+
+    if (imgUrl) {
+      chrome.runtime.sendMessage({ type: 'SET_PRODUCT_IMAGE', url: imgUrl });
+    }
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    detectImage();
+  } else {
+    document.addEventListener('DOMContentLoaded', detectImage);
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifest_version": 3,
+  "name": "AI Virtual Try-On",
+  "version": "1.0",
+  "description": "Try on clothes virtually from supported e-commerce sites.",
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://*.amazon.com/*",
+    "https://*.myntra.com/*",
+    "https://*.flipkart.com/*",
+    "https://*.zara.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.amazon.com/*",
+        "https://*.myntra.com/*",
+        "https://*.flipkart.com/*",
+        "https://*.zara.com/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "AI Virtual Try-On"
+  }
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,14 @@
+body {
+  min-width: 300px;
+  font-family: Arial, sans-serif;
+  text-align: center;
+}
+
+#product-image, #result-image {
+  max-width: 100%;
+  height: auto;
+}
+
+#loading {
+  margin-top: 10px;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>AI Virtual Try-On</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <div id="content">
+    <h1>AI Virtual Try-On</h1>
+    <div id="product-container">
+      <p>Detected product:</p>
+      <img id="product-image" src="" alt="Product" />
+    </div>
+    <div>
+      <input type="file" id="user-photo" accept="image/*">
+    </div>
+    <button id="try-btn">Try It On</button>
+    <div id="loading" hidden>Loading...</div>
+    <div id="result-container" hidden>
+      <p>Result:</p>
+      <img id="result-image" src="" alt="Result" />
+    </div>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,70 @@
+// Popup script for AI Virtual Try-On
+const API_ENDPOINT = 'https://httpbin.org/post'; // Replace with real backend
+
+let userPhoto = null;
+let productImageUrl = null;
+
+function loadProductImage() {
+  chrome.runtime.sendMessage({ type: 'GET_PRODUCT_IMAGE' }, (response) => {
+    productImageUrl = response?.url || null;
+    if (productImageUrl) {
+      document.getElementById('product-image').src = productImageUrl;
+    }
+  });
+}
+
+function init() {
+  loadProductImage();
+  chrome.storage.local.get('userPhoto', (data) => {
+    if (data.userPhoto) {
+      userPhoto = data.userPhoto;
+    }
+  });
+
+  document.getElementById('user-photo').addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = function() {
+      userPhoto = reader.result.split(',')[1]; // base64
+      chrome.storage.local.set({ userPhoto });
+    };
+    reader.readAsDataURL(file);
+  });
+
+  document.getElementById('try-btn').addEventListener('click', async () => {
+    if (!userPhoto || !productImageUrl) {
+      alert('Missing user photo or product image');
+      return;
+    }
+
+    document.getElementById('loading').hidden = false;
+    document.getElementById('result-container').hidden = true;
+
+    try {
+      const res = await fetch(API_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_photo: userPhoto,
+          product_image_url: productImageUrl,
+        }),
+      });
+      const json = await res.json();
+      if (json.result_image) {
+        document.getElementById('result-image').src = `data:image/png;base64,${json.result_image}`;
+        document.getElementById('result-container').hidden = false;
+      } else {
+        alert('API did not return an image');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Error contacting API');
+    } finally {
+      document.getElementById('loading').hidden = true;
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- add Manifest V3 Chrome extension scaffolding for AI-powered virtual try-on.
- implement background worker, content script, and popup UI with upload and backend integration.
- document usage and supported e-commerce sites.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c6c958408c832b9aa1416c9660385c